### PR TITLE
Use yaml.safe_load() instead of load()

### DIFF
--- a/pycomplexes/pycomplexes/addlinker.py
+++ b/pycomplexes/pycomplexes/addlinker.py
@@ -138,7 +138,7 @@ class Addlinker(six.with_metaclass(_ScriptMeta)):
         util.check_file_exists(args.config)
 
         with open(args.config) as f:
-            config = yaml.load(f)
+            config = yaml.safe_load(f)
 
         cplx = config["structure"]
         traj = config["output"]["file"]
@@ -148,7 +148,7 @@ class Addlinker(six.with_metaclass(_ScriptMeta)):
         util.check_file_exists(traj)
 
         with open(cplx) as fh:
-            cplx = yaml.load(fh)
+            cplx = yaml.safe_load(fh)
 
         sim = mda.Universe(top, traj)
         addlinker(cplx, sim, args.out, args.start, args.stop, args.step)

--- a/pycomplexes/pycomplexes/convert.py
+++ b/pycomplexes/pycomplexes/convert.py
@@ -496,7 +496,7 @@ class Convert(six.with_metaclass(_ScriptMeta)):
             raise IOError("File does not exist: {}".format(args.top))
 
         with open(args.top) as f:
-            top = yaml.load(f)
+            top = yaml.safe_load(f)
 
         cplx = convert(
             top,

--- a/pycomplexes/pycomplexes/convert.py
+++ b/pycomplexes/pycomplexes/convert.py
@@ -95,7 +95,8 @@ _DEFAULT_DEFINITIONS = """
   - domain-type-pair: [tube, tube]
     function: None
 """
-DEFAULT_DEFINITIONS = yaml.load(_DEFAULT_DEFINITIONS)
+
+DEFAULT_DEFINITIONS = yaml.safe_load(_DEFAULT_DEFINITIONS)
 
 
 def charges(residues, charge_assignment=CHARGE_ASSIGNMENT):

--- a/pycomplexes/pycomplexes/equilibration.py
+++ b/pycomplexes/pycomplexes/equilibration.py
@@ -80,7 +80,7 @@ def argument_processing(args):
     """
     if args.complexes_config:
         with open(args.complexes_config, "r") as f:
-            config = yaml.load(f)
+            config = yaml.safe_load(f)
         equilibrate_cplx = config["structure"]
         trajectory = config["output"]["file"]
         reference_pdb = trajectory[:-4] + "_reference.pdb"
@@ -149,7 +149,7 @@ class Equilibration(six.with_metaclass(_ScriptMeta)):
         )
 
         with open(equilibrate_cplx) as f:
-            system = yaml.load(f)
+            system = yaml.safe_load(f)
 
         # update the current system-coordinates to coordinates at specified frame (parsed argument)
         eq_u = mda.Universe(reference_pdb, trajectory)

--- a/pycomplexes/pycomplexes/forcefield.py
+++ b/pycomplexes/pycomplexes/forcefield.py
@@ -40,7 +40,7 @@ def known_forcefields():
 
 def read_forcefield(ff_file):
     with open(ff_file) as fh:
-        return yaml.load(fh)
+        return yaml.safe_load(fh)
 
 
 def scale_interaction(old_forcefield, scale, offset):

--- a/pycomplexes/pycomplexes/tests/test_addlinker.py
+++ b/pycomplexes/pycomplexes/tests/test_addlinker.py
@@ -9,7 +9,7 @@ from pycomplexes.testing import datafiles
 @pytest.fixture
 def cplx(datafiles):
     with open(datafiles["chmp3.cplx"]) as fh:
-        return yaml.load(fh)
+        return yaml.safe_load(fh)
 
 
 @pytest.fixture

--- a/pycomplexes/pycomplexes/tests/test_convert.py
+++ b/pycomplexes/pycomplexes/tests/test_convert.py
@@ -63,12 +63,12 @@ topology:
 
 @pytest.mark.parametrize("top", [top_with_copies, top_without_copies])
 def test_parse_top_file(top, data):
-    top = yaml.load(top.format(data.folder))
+    top = yaml.safe_load(top.format(data.folder))
 
     cplx = convert.convert(top, random=False)
 
     with open(data["test_convert.cplx"], "r") as f:
-        expected_cplx = yaml.load(f)
+        expected_cplx = yaml.safe_load(f)
 
     assert_equal(cplx, expected_cplx)
 
@@ -91,7 +91,7 @@ topology:
                 type: gaussian
                 selection: 'all'
     """
-    return yaml.load(top_yaml)
+    return yaml.safe_load(top_yaml)
 
 
 def test_chain_ids(datafiles):
@@ -241,7 +241,7 @@ def test_ProteinDomain(datafiles):
 
 def test_ProteinTopology(datafiles):
     pdb_file = datafiles["chmp3_model.pdb"]
-    topology = yaml.load(
+    topology = yaml.safe_load(
         """
     coordinate-file: '{}'
     domains:

--- a/pycomplexes/pycomplexes/tests/test_equilibration.py
+++ b/pycomplexes/pycomplexes/tests/test_equilibration.py
@@ -44,7 +44,7 @@ def test_update_coordinates(datafiles):
     """
     start_cplx = datafiles["lj-sys.cplx"]
     with open(start_cplx) as f:
-        system = yaml.load(f)
+        system = yaml.safe_load(f)
     test_reference = datafiles["test_traj_reference.pdb"]
     test_traj = datafiles["test_traj.xtc"]
     eq_u = mda.Universe(test_reference, test_traj)
@@ -52,7 +52,7 @@ def test_update_coordinates(datafiles):
     system = equ.update_coordinates(system, eq_u)
     updated_cplx = datafiles["lj-sys_updated.cplx"]
     with open(updated_cplx, "r") as f:
-        updated_reference = yaml.load(f)
+        updated_reference = yaml.safe_load(f)
     assert_equal(system, updated_reference)
 
 

--- a/pycomplexes/pycomplexes/tests/test_ph.py
+++ b/pycomplexes/pycomplexes/tests/test_ph.py
@@ -192,8 +192,8 @@ topologies:
   name: donald
   ndomains: 2
    """
-    expected_cplx = yaml.load(expected_cplx)
+    expected_cplx = yaml.safe_load(expected_cplx)
     with open(data["test_ph.cplx"]) as f:
-        test_cplx = yaml.load(f)
+        test_cplx = yaml.safe_load(f)
     test_cplx = ph.change_charges(test_cplx, 15.)
     assert_equal(test_cplx, expected_cplx)

--- a/pycomplexes/pycomplexes/tests/test_visualize.py
+++ b/pycomplexes/pycomplexes/tests/test_visualize.py
@@ -612,7 +612,7 @@ def test_write_to_file(tmpdir):
     test_string = "This is only test-content"
     vis.write_to_file(test_string, outputfilename)
     with open(outputfilename, "r") as f:
-        read_string = yaml.load(f)
+        read_string = yaml.safe_load(f)
     assert read_string == test_string
 
 

--- a/pycomplexes/pycomplexes/visualize.py
+++ b/pycomplexes/pycomplexes/visualize.py
@@ -628,7 +628,7 @@ def argument_processing(args):
     if args.complexes_config:
         print("Extracting Information from complexes-config: " + args.complexes_config)
         with open(args.complexes_config) as f:
-            com_config = yaml.load(f)
+            com_config = yaml.safe_load(f)
         cplx = com_config["structure"]
         xtc = com_config["output"]["file"]
         vmd_top = os.path.splitext(com_config["output"]["file"])[0] + "_reference.pdb"
@@ -651,7 +651,7 @@ def argument_processing(args):
         print("Extracting Information from visualization-config: " + args.vis_config)
         print("Note that any additional console argument will be ignored")
         with open(args.vis_config) as f:
-            vis_config = yaml.load(f)
+            vis_config = yaml.safe_load(f)
         cplx = vis_config["cplx"]
         xtc = vis_config["xtc"]
         vmd_top = vis_config["vmd_top"]
@@ -811,7 +811,7 @@ class Visualize(six.with_metaclass(_ScriptMeta)):
         )
 
         with open(cplx) as f:
-            topology = yaml.load(f)
+            topology = yaml.safe_load(f)
         print("Given topology: " + cplx)
         # check whether coloring was overwritten by unify-argument:
         if unify:

--- a/pycomplexes/setup.py
+++ b/pycomplexes/setup.py
@@ -23,7 +23,7 @@ setup(name='pycomplexes',
       description='python helper library for complexes++',
       author='Max Linke',
       packages=find_packages(),
-      install_requires=['numpy', 'pyyaml', 'six', 'pandas', 'tqdm', 'numba',
+      install_requires=['numpy', 'pyyaml>=5.1', 'six', 'pandas', 'tqdm', 'numba',
                         'MDAnalysis>=0.19.0', 'backports.functools_lru_cache'],
       entry_points={'console_scripts':
                     ['pycomplexes=pycomplexes.scripts:main']},


### PR DESCRIPTION
Supposed to fix #3 


yaml.load() is exploitable and therefore deprecated.
I used yaml.safe_load() everywhere instead. Users now need to
have considerably new version of pyyaml installed.