### PR TITLE
Forbid unknow params, register the one accessed with hasKey

### DIFF
--- a/complexes++/ext/CLsimple/clsimple.hpp
+++ b/complexes++/ext/CLsimple/clsimple.hpp
@@ -122,7 +122,7 @@ class CLsimple{
                 bool convertionOkStr;
                 auto valueStr = Convert<std::string>(inValue, &convertionOkStr);
                 if(_variable && convertionOkStr){
-                    _variable->get().push_back(valueStr == "TRUE" || valueStr == "true");
+                    _variable->get().push_back(valueStr == "TRUE" || valueStr == "true" || valueStr == "True");
                     return true;
                 }
                 return false;
@@ -174,7 +174,7 @@ class CLsimple{
                 bool convertionOkStr;
                 auto valueStr = Convert<std::string>(inValue, &convertionOkStr);
                 if(_variable && convertionOkStr){
-                    _variable->get() = (valueStr == "TRUE" || valueStr == "true");
+                    _variable->get() = (valueStr == "TRUE" || valueStr == "true" || valueStr == "True");
                     return true;
                 }
                 return false;
@@ -332,6 +332,7 @@ public:
                     }
                     else{
                         parseIsOK &= param->applyValue(_argv[pos+1]);
+                        usedFields += 1;
                     }
                 }
                 else{

--- a/complexes++/ext/CLsimple/clsimple.hpp
+++ b/complexes++/ext/CLsimple/clsimple.hpp
@@ -16,6 +16,7 @@
 #include <typeinfo>
 #include <type_traits>
 #include <limits>
+#include <cassert>
 
 class CLsimple{
     template <class ParamType>
@@ -54,21 +55,25 @@ class CLsimple{
     };
 
     class AbstractParam{
-        const std::string _key;
+        const std::vector<std::string> _keys;
         const std::string _help;
         const ParamTypes _paramType;
         const bool _isMandatory;
 
     public:
-        AbstractParam(std::string inKey,
+        AbstractParam(std::vector<std::string> inKeys,
                       std::string inHelp,
                       const ParamTypes inType,
                       const bool inIsMandatory):
-            _key(std::move(inKey)), _help(std::move(inHelp)),
-            _paramType(inType), _isMandatory(inIsMandatory){}
+            _keys(std::move(inKeys)), _help(std::move(inHelp)),
+            _paramType(inType), _isMandatory(inIsMandatory){
+            assert(_keys.size());
+        }
 
-        std::string getKey() const{
-            return _key;
+        virtual ~AbstractParam(){}
+
+        std::vector<std::string> getKeys() const{
+            return _keys;
         }
 
         std::string getHelp() const{
@@ -102,12 +107,12 @@ class CLsimple{
         const std::vector<ParamType> _default;
 
     public:
-        MultiParam(std::string inKey,
+        MultiParam(std::vector<std::string> inKeys,
                    std::string inHelp,
                    const bool inIsMandatory,
                    std::optional<std::reference_wrapper<std::vector<ParamType>>> inVariable,
                    std::vector<ParamType> inDefault):
-            AbstractParam(std::move(inKey), std::move(inHelp), Multi, inIsMandatory),
+            AbstractParam(std::move(inKeys), std::move(inHelp), Multi, inIsMandatory),
             _variable(std::move(inVariable)),
             _default(std::move(inDefault)){}
 
@@ -154,12 +159,12 @@ class CLsimple{
         const ParamType _default;
 
     public:
-        Param(std::string inKey,
+        Param(std::vector<std::string> inKeys,
               std::string inHelp,
               const bool inIsMandatory,
               std::optional<std::reference_wrapper<ParamType>> inVariable,
               ParamType inDefault):
-            AbstractParam(std::move(inKey), std::move(inHelp), Single, inIsMandatory),
+            AbstractParam(std::move(inKeys), std::move(inHelp), Single, inIsMandatory),
             _variable(std::move(inVariable)),
             _default(std::move(inDefault)){}
 
@@ -202,10 +207,10 @@ class CLsimple{
 
     class ParamNoArg : public AbstractParam{
     public:
-        ParamNoArg(std::string inKey,
+        ParamNoArg(std::vector<std::string> inKeys,
               std::string inHelp,
                    const bool inIsMandatory):
-            AbstractParam(std::move(inKey), std::move(inHelp), NoArg, inIsMandatory){}
+            AbstractParam(std::move(inKeys), std::move(inHelp), NoArg, inIsMandatory){}
 
         bool applyValue(const std::string& inValue) final{
             return true;
@@ -243,7 +248,81 @@ class CLsimple{
         return std::pair<std::string,std::string>(std::move(key), std::move(value));
     }
 
+    template <class ParamType>
+    void processParam(ParamType&& param, bool* parseIsOK = nullptr, int* usedFields = nullptr) const {
+        const auto& keys = param->getKeys();
+        int pos = -1;
+        for(const auto& key : keys){
+            const int testPos = getKeyPos(key);
+            if(testPos != -1){
+                pos = testPos;
+                break;
+            }
+        }
+
+        if(pos == -1){
+            param->applyDefault();
+            if(param->isMandatory()){
+                if(parseIsOK){
+                    (*parseIsOK) = false;
+                }
+            }
+        }
+        else{
+            if(usedFields){
+                (*usedFields) += 1;
+            }
+            if(param->isNoArg()){
+                // Do nothing
+            }
+            else if(IsKeyValueFormat(_argv[pos])){
+                const auto keyValue = SplitKeyValue(_argv[pos]);
+                const bool res = param->applyValue(std::get<1>(keyValue));
+                if(parseIsOK){
+                    (*parseIsOK) &= res;
+                }
+            }
+            else if(pos+1 != int(_argv.size())){
+                if(param->isMulti()){
+                    int idxVal = pos + 1;
+                    while(idxVal != int(_argv.size()) && !StrSeemsAKey(_argv[idxVal])){
+                        const bool res = param->applyValue(_argv[idxVal]);
+                        if(parseIsOK){
+                            (*parseIsOK) &= res;
+                        }
+                        idxVal += 1;
+                        if(usedFields){
+                            (*usedFields) += 1;
+                        }
+                    }
+                    if(idxVal == pos + 1){
+                        param->applyDefault();
+                        if(parseIsOK){
+                            (*parseIsOK) = false;
+                        }
+                    }
+                }
+                else{
+                    const bool res = param->applyValue(_argv[pos+1]);
+                    if(parseIsOK){
+                        (*parseIsOK) &= res;
+                    }
+                    if(usedFields){
+                        (*usedFields) += 1;
+                    }
+                }
+            }
+            else{
+                param->applyDefault();
+                if(parseIsOK){
+                    (*parseIsOK) = false;
+                }
+            }
+        }
+    }
+
     const std::string _title;
+    std::string _exec;
 
     std::vector<std::string> _argv;
     std::shared_ptr<std::vector<std::unique_ptr<AbstractParam>>> _params;
@@ -262,6 +341,9 @@ public:
           _failsIfInvalid(inFailsIfInvalid),
           _acceptUnregisteredParams(inAcceptUnregisteredParams),
           _isValid(true) {
+        if(argc){
+            _exec = argv[0];
+        }
         _argv.reserve(argc-1);
         for(int idxArg = 1 ; idxArg < argc ; ++idxArg){
             _argv.emplace_back(argv[idxArg]);
@@ -296,50 +378,38 @@ public:
         return getKeyPos(inKey) != -1;
     }
 
+    template <class ParamType>
+    std::vector<ParamType> getValues(std::vector<std::string> inKeys,
+                  std::vector<ParamType> inDefaultValue = std::vector<ParamType>(),
+                  bool* outOk = nullptr) const{
+        std::vector<ParamType> variable;
+        std::optional<std::reference_wrapper<std::vector<ParamType>>> variableRef(variable);
+        MultiParam<ParamType> newParam(std::move(inKeys), "", false,
+                                                    std::move(variableRef),
+                                                    std::move(inDefaultValue));
+        processParam(&newParam, outOk);
+        return variable;
+    }
+
+    template <class ParamType>
+    ParamType getValue(std::vector<std::string> inKeys,
+                  ParamType inDefaultValue = ParamType(),
+                  bool* outOk = nullptr) const{
+        ParamType variable;
+        std::optional<std::reference_wrapper<ParamType>> variableRef(variable);
+        Param<ParamType> newParam(std::move(inKeys), "", false,
+                                                    std::move(variableRef),
+                                                    std::move(inDefaultValue));
+        processParam(&newParam, outOk);
+        return variable;
+    }
+
     bool parse(){
         bool parseIsOK = true;
         int usedFields = 0;
 
         for(auto& param : *_params){
-            const int pos = getKeyPos(param->getKey());
-            if(pos == -1){
-                param->applyDefault();
-                if(param->isMandatory()){
-                    parseIsOK = false;
-                }
-            }
-            else{
-                usedFields += 1;
-                if(param->isNoArg()){
-                    // Do nothing
-                }
-                else if(IsKeyValueFormat(_argv[pos])){
-                    const auto keyValue = SplitKeyValue(_argv[pos]);
-                    parseIsOK &= param->applyValue(std::get<1>(keyValue));
-                }
-                else if(pos+1 != int(_argv.size())){
-                    if(param->isMulti()){
-                        int idxVal = pos + 1;
-                        while(idxVal != int(_argv.size()) && !StrSeemsAKey(_argv[idxVal])){
-                            parseIsOK &= param->applyValue(_argv[idxVal]);
-                            idxVal += 1;
-                            usedFields += 1;
-                        }
-                        if(idxVal == pos + 1){
-                            param->applyDefault();
-                            parseIsOK = false;
-                        }
-                    }
-                    else{
-                        parseIsOK &= param->applyValue(_argv[pos+1]);
-                        usedFields += 1;
-                    }
-                }
-                else{
-                    param->applyDefault();
-                    parseIsOK = false;
-                }
-            }
+            processParam(param, &parseIsOK, &usedFields);
         }
         if(_failsIfInvalid){
             _isValid = parseIsOK;
@@ -351,12 +421,12 @@ public:
     }
 
     template <class ParamType>
-    void addMultiParameter(std::string inKey, std::string inHelp,
+    void addMultiParameter(std::vector<std::string> inKeys, std::string inHelp,
                            std::optional<std::reference_wrapper<std::vector<ParamType>>> inVariable = std::nullopt,
                            std::vector<ParamType> inDefaultValue = std::vector<ParamType>(),
                            const bool inIsMandatory = false){
         std::unique_ptr<AbstractParam> newParam(new MultiParam<ParamType>(
-                                                    std::move(inKey),
+                                                    std::move(inKeys),
                                                     std::move(inHelp),
                                                     inIsMandatory,
                                                     std::move(inVariable),
@@ -366,12 +436,12 @@ public:
     }
 
     template <class ParamType>
-    void addParameter(std::string inKey, std::string inHelp,
+    void addParameter(std::vector<std::string> inKeys, std::string inHelp,
                       std::optional<std::reference_wrapper<ParamType>> inVariable = std::nullopt,
                       ParamType inDefaultValue = ParamType(),
                       const bool inIsMandatory = false){
         std::unique_ptr<AbstractParam> newParam(new Param<ParamType>(
-                                                    std::move(inKey),
+                                                    std::move(inKeys),
                                                     std::move(inHelp),
                                                     inIsMandatory,
                                                     std::move(inVariable),
@@ -380,10 +450,10 @@ public:
         (*_params).emplace_back(std::move(newParam));
     }
 
-    void addParameterNoArg(std::string inKey, std::string inHelp,
+    void addParameterNoArg(std::vector<std::string> inKeys, std::string inHelp,
                            const bool inIsMandatory = false){
         std::unique_ptr<AbstractParam> newParam(new ParamNoArg(
-                                                    std::move(inKey),
+                                                    std::move(inKeys),
                                                     std::move(inHelp),
                                                     inIsMandatory
                                                     ));
@@ -392,15 +462,45 @@ public:
 
     template <class StreamClass>
     void printHelp(StreamClass& inStream) const{
+        auto join = [](auto&& elements, auto&& delimiter) -> std::string {
+            std::string res;
+            for(const auto& elm : elements){
+                if(std::size(res)){
+                    res += delimiter;
+                }
+                res += elm;
+            }
+            return res;
+        };
+
+        inStream << "[HELP] \n";
         inStream << "[HELP] " << _title << "\n";
+        inStream << "[HELP] \n";
         for(auto& param : *_params){
-            inStream << "[HELP] Parameter name: " << param->getKey() << "\n";
+            inStream << "[HELP] Parameter names: {" << join(param->getKeys(),", ") << "}\n";
             inStream << "[HELP]  - Description: " << param->getHelp() << "\n";
             inStream << "[HELP]  - Type: " << param->getTypeStr() << "\n";
             inStream << "[HELP]  - Mandatory: " << (param->isMandatory()?"True":"False") << "\n";
             inStream << "[HELP]\n";
         }
+        inStream << "[HELP]" << std::endl;
+
+
+        inStream << "[HELP] Command line with all args: " << _exec << " ";
+        for(auto& param : *_params){
+            assert(param->getKeys().size());
+            if(param->isMulti()){
+                inStream << "--" << param->getKeys()[0] << " [" << param->getTypeStr() << "] ";
+            }
+            else if(param->isSingle()){
+                inStream << "--" << param->getKeys()[0] << "=[" << param->getTypeStr() << "] ";
+            }
+            else{
+                inStream << "--" << param->getKeys()[0] << " ";
+            }
+        }
         inStream << std::endl;
+        inStream << "[HELP]" << std::endl;
     }
 
     template <class ValType>

--- a/complexes++/ext/CLsimple/clsimple.hpp
+++ b/complexes++/ext/CLsimple/clsimple.hpp
@@ -17,7 +17,6 @@
 #include <type_traits>
 #include <limits>
 
-
 class CLsimple{
     template <class ParamType>
     static ParamType Convert(const std::string& str, bool* outFlag = nullptr){

--- a/complexes++/src/main.cpp
+++ b/complexes++/src/main.cpp
@@ -15,11 +15,14 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with complexes++.  If not, see <https://www.gnu.org/licenses/>
+#include "setup/copyright.h"
 #include "setup/application.h"
 #include "util/log.h"
 #include "util/timer.h"
 
 int main(int argc, char **argv) {
+  setup::printGPL();
+
   auto args = setup::CLIArgs(argc, argv);
   if (args.parse() == false || args.hasKey("help")) {
     args.printHelp(std::cout);

--- a/complexes++/src/main.cpp
+++ b/complexes++/src/main.cpp
@@ -21,7 +21,7 @@
 
 int main(int argc, char **argv) {
   auto args = setup::CLIArgs(argc, argv);
-  if (args.parse() == false) {
+  if (args.parse() == false || args.hasKey("help")) {
     args.printHelp(std::cout);
     return 0;
   }

--- a/complexes++/src/mainmpi.cpp
+++ b/complexes++/src/mainmpi.cpp
@@ -38,7 +38,7 @@ int main(int argc, char **argv) {
     args.printHelp(std::cout);
     return 0;
   }
-  mpi::MpiApplication app(args, argv, args);
+  mpi::MpiApplication app(args);
   auto timer = util::Timer();
   auto res = app.run();
   fmt::print(std::clog, "[LOG] total runtime = {}s\n",

--- a/complexes++/src/mainmpi.cpp
+++ b/complexes++/src/mainmpi.cpp
@@ -19,6 +19,7 @@
 #include <fmt/format.h>
 #include <iostream>
 
+#include "setup/copyright.h"
 #include "complexesconfig.h"
 #include "util/log.h"
 #include "util/timer.h"
@@ -30,10 +31,12 @@
 #include "mpi/mpiapplication.h"
 
 int main(int argc, char **argv) {
-  auto args = mpi::MPICLIArgs();
-  auto status = args.parse(argc, argv);
-  if (status != 0) {
-    return status;
+  setup::printGPL();
+
+  auto args = setup::MPICLIArgs(argc, argv);
+  if (args.parse() == false || args.hasKey("help")) {
+    args.printHelp(std::cout);
+    return 0;
   }
   mpi::MpiApplication app(args, argv, args);
   auto timer = util::Timer();

--- a/complexes++/src/mpi/mpicliargs.h
+++ b/complexes++/src/mpi/mpicliargs.h
@@ -25,7 +25,7 @@ namespace mpi {
 class MpiCLIArgs : public setup::CLIArgs {
 public:
   MpiCLIArgs(const int &argc, const char *const argv[]) : setup::CLIArgs(argc, argv) {
-      args.addParameter<int>("mpi-partitions", "number of simulation per nodes",
+      args.addParameter<int>({"mpi-partitions", "np"}, "number of simulation per nodes",
                              mpi_partitions, 1);
   }
 

--- a/complexes++/src/setup/application.cpp
+++ b/complexes++/src/setup/application.cpp
@@ -24,34 +24,6 @@
 
 namespace setup {
 
-void printGPL() {
-  std::cout << " Copyright (c) 2018 the complexes++ development team and "
-               "contributors \n";
-  std::cout << " (see the file AUTHORS for the full list of names) \n";
-  std::cout << " \n";
-  std::cout << " complexes++ is free software: you can redistribute it and/or "
-               "modify \n";
-  std::cout << " it under the terms of the Lesser GNU General Public License "
-               "as published by \n";
-  std::cout << " the Free Software Foundation, either version 3 of the "
-               "License, or \n";
-  std::cout << " (at your option) any later version. \n";
-  std::cout << " \n";
-  std::cout
-      << " complexes++ is distributed in the hope that it will be useful, \n";
-  std::cout
-      << " but WITHOUT ANY WARRANTY; without even the implied warranty of \n";
-  std::cout
-      << " MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the \n";
-  std::cout << " GNU General Public License for more details. \n";
-  std::cout << " \n";
-  std::cout << " You should have received a copy of the GNU General Public "
-               "License \n";
-  std::cout << " along with complexes++.  If not, see "
-               "<https://www.gnu.org/licenses/> \n";
-  std::cout << std::endl;
-}
-
 int Application::multiDirExecution() const {
   if (m_args.rerun) {
     throw std::invalid_argument(
@@ -146,8 +118,6 @@ int Application::singleSrcExecution() const {
 }
 
 int Application::run() {
-  printGPL();
-
   if (m_args.hasKey("version")) {
     fmt::print(util::buildInformation());
     return 0;

--- a/complexes++/src/setup/cliargs.h
+++ b/complexes++/src/setup/cliargs.h
@@ -35,6 +35,9 @@ public:
         args("COMPLEXES is a coarse grained simulation tool",
              argc, argv){
 
+        args.addParameterNoArg("help", "to print this help");
+        args.addParameterNoArg("version", "to get the version of the current binary");
+
         args.addMultiParameter<std::string>("multidir", "multiple simulation directories",
                                         multidir);
         args.addParameter<std::string>("config", "config file",
@@ -45,8 +48,6 @@ public:
                                 rerun, false);
         args.addParameter<std::string>("restart", "restart file",
                                        restart, "");
-        args.addParameter<bool>("version", "show version",
-                                version, false);
         args.addParameter<int>("replex", "number of sweeps between exchanges",
                                replex, 0);
         args.addParameter<int>("replex_stat", "number of sweeps between statistic output",
@@ -89,7 +90,6 @@ public:
     bool backup;
     bool rerun;
     std::string restart;
-    bool version;
     int replex;
     int replex_stat;
     std::string replex_accept;

--- a/complexes++/src/setup/cliargs.h
+++ b/complexes++/src/setup/cliargs.h
@@ -35,13 +35,13 @@ public:
         args("COMPLEXES is a coarse grained simulation tool",
              argc, argv){
 
-        args.addParameterNoArg({"help"}, "to print this help");
-        args.addParameterNoArg({"version"}, "to get the version of the current binary");
+        args.addParameterNoArg({"help"}, "to print this help", 0);
+        args.addParameterNoArg({"version"}, "to get the version of the current binary", 1);
 
         args.addMultiParameter<std::string>({"multidir"}, "multiple simulation directories",
                                         multidir);
         args.addParameter<std::string>({"config", "c"}, "config file",
-                                       config, "");
+                                       config, "", 2);
         args.addParameter<bool>({"backup"}, "backup of files",
                                 backup, true);
         args.addParameter<bool>({"rerun"}, "recalculate energies from trajectory",

--- a/complexes++/src/setup/cliargs.h
+++ b/complexes++/src/setup/cliargs.h
@@ -42,6 +42,8 @@ public:
                                         multidir);
         args.addParameter<std::string>("config", "config file",
                                        config, "");
+        args.addParameter<std::string>("c", "same as --config",
+                                       config, "");
         args.addParameter<bool>("backup", "backup of files",
                                 backup, true);
         args.addParameter<bool>("rerun", "recalculate energies from trajectory",

--- a/complexes++/src/setup/cliargs.h
+++ b/complexes++/src/setup/cliargs.h
@@ -35,34 +35,32 @@ public:
         args("COMPLEXES is a coarse grained simulation tool",
              argc, argv){
 
-        args.addParameterNoArg("help", "to print this help");
-        args.addParameterNoArg("version", "to get the version of the current binary");
+        args.addParameterNoArg({"help"}, "to print this help");
+        args.addParameterNoArg({"version"}, "to get the version of the current binary");
 
-        args.addMultiParameter<std::string>("multidir", "multiple simulation directories",
+        args.addMultiParameter<std::string>({"multidir"}, "multiple simulation directories",
                                         multidir);
-        args.addParameter<std::string>("config", "config file",
+        args.addParameter<std::string>({"config", "c"}, "config file",
                                        config, "");
-        args.addParameter<std::string>("c", "same as --config",
-                                       config, "");
-        args.addParameter<bool>("backup", "backup of files",
+        args.addParameter<bool>({"backup"}, "backup of files",
                                 backup, true);
-        args.addParameter<bool>("rerun", "recalculate energies from trajectory",
+        args.addParameter<bool>({"rerun"}, "recalculate energies from trajectory",
                                 rerun, false);
-        args.addParameter<std::string>("restart", "restart file",
+        args.addParameter<std::string>({"restart"}, "restart file",
                                        restart, "");
-        args.addParameter<int>("replex", "number of sweeps between exchanges",
+        args.addParameter<int>({"replex"}, "number of sweeps between exchanges",
                                replex, 0);
-        args.addParameter<int>("replex_stat", "number of sweeps between statistic output",
+        args.addParameter<int>({"replex_stat"}, "number of sweeps between statistic output",
                                replex_stat, 1000);
-        args.addParameter<std::string>("replex_accept", "exchange accept function",
+        args.addParameter<std::string>({"replex_accept"}, "exchange accept function",
                                        replex_accept, "");
-        args.addParameter<std::string>("movestats",
+        args.addParameter<std::string>({"movestats"},
                                      "specify the move statistics to show. Could be pertype, "
                                      "perdomain, all, none",
                                       movestats, "pertype");
-        args.addParameter<int>("nb-threads", "number of threads",
+        args.addParameter<int>({"nb-threads"}, "number of threads",
                                nb_threads, omp_get_max_threads());
-        args.addParameter<std::string>("replex_verbosity", "exchange log verbosity (stats, all, none)",
+        args.addParameter<std::string>({"replex_verbosity"}, "exchange log verbosity (stats, all, none)",
                                        replex_verbosity, "stats");
 
     }

--- a/complexes++/src/setup/cliargs.h
+++ b/complexes++/src/setup/cliargs.h
@@ -58,7 +58,7 @@ public:
                                      "specify the move statistics to show. Could be pertype, "
                                      "perdomain, all, none",
                                       movestats, "pertype");
-        args.addParameter<int>("nb_threads", "number of threads",
+        args.addParameter<int>("nb-threads", "number of threads",
                                nb_threads, omp_get_max_threads());
         args.addParameter<std::string>("replex_verbosity", "exchange log verbosity (stats, all, none)",
                                        replex_verbosity, "stats");

--- a/complexes++/src/setup/copyright.h
+++ b/complexes++/src/setup/copyright.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2018 the complexes++ development team and contributors
+// (see the file AUTHORS for the full list of names)
+//
+// This file is part of complexes++.
+//
+// complexes++ is free software: you can redistribute it and/or modify
+// it under the terms of the Lesser GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// complexes++ is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with complexes++.  If not, see <https://www.gnu.org/licenses/>
+#ifndef COPYRIGHT_H
+#define COPYRIGHT_H
+
+#include <iostream>
+
+namespace setup {
+
+inline void printGPL() {
+  std::cout << " Copyright (c) 2018 the complexes++ development team and "
+               "contributors \n";
+  std::cout << " (see the file AUTHORS for the full list of names) \n";
+  std::cout << " \n";
+  std::cout << " complexes++ is free software: you can redistribute it and/or "
+               "modify \n";
+  std::cout << " it under the terms of the Lesser GNU General Public License "
+               "as published by \n";
+  std::cout << " the Free Software Foundation, either version 3 of the "
+               "License, or \n";
+  std::cout << " (at your option) any later version. \n";
+  std::cout << " \n";
+  std::cout
+      << " complexes++ is distributed in the hope that it will be useful, \n";
+  std::cout
+      << " but WITHOUT ANY WARRANTY; without even the implied warranty of \n";
+  std::cout
+      << " MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the \n";
+  std::cout << " GNU General Public License for more details. \n";
+  std::cout << " \n";
+  std::cout << " You should have received a copy of the GNU General Public "
+               "License \n";
+  std::cout << " along with complexes++.  If not, see "
+               "<https://www.gnu.org/licenses/> \n";
+  std::cout << std::endl;
+}
+
+}
+
+#endif // COPYRIGHT_H

--- a/complexes++/src/util/file.cpp
+++ b/complexes++/src/util/file.cpp
@@ -52,7 +52,7 @@ std::string basename(const std::string &file) { return fs::path(file).stem().str
 
 void throwIfFileDoesNotExists(const std::string &file) {
   if (!fs::exists(file)) {
-    throw std::invalid_argument(fmt::format("{} <-- does not exist.\n", file));
+    throw std::invalid_argument(fmt::format("File \"{}\" does not exist.\n", file));
   }
 }
 

--- a/complexes++/test/app-test/membrane-energy/generate-reference-energies.ipynb
+++ b/complexes++/test/app-test/membrane-energy/generate-reference-energies.ipynb
@@ -449,7 +449,7 @@
     "for folder in Residue-*\n",
     "do\n",
     "   cd $folder\n",
-    "   complexes++ -c config.yaml --rerun=True --nb-thread=1\n",
+    "   complexes++ -c config.yaml --rerun=True --nb-threads=1\n",
     "   cd ..\n",
     "done"
    ]

--- a/complexes++/test/app-test/membrane-energy/run.sh
+++ b/complexes++/test/app-test/membrane-energy/run.sh
@@ -8,7 +8,7 @@ function run {
     for folder in Residue-*
     do
         cd $folder
-        $complexes -c config.yaml --rerun=True --nb-thread=1 --backup=false
+        $complexes -c config.yaml --rerun=True --nb-threads=1 --backup=false
         cd ..
     done
 }

--- a/complexes++/test/app-test/regression-energy/run.sh
+++ b/complexes++/test/app-test/regression-energy/run.sh
@@ -5,7 +5,7 @@ set -e
 
 function run {
     complexes=../../../src/complexes++
-    $complexes --backup=false --config=rerun.conf --rerun=True --nb-thread=1
+    $complexes --backup=false --config=rerun.conf --rerun=True --nb-threads=1
 }
 
 function testit {

--- a/complexes++/test/app-test/soft-core-energy/generate-reference-softcore-potential.ipynb
+++ b/complexes++/test/app-test/soft-core-energy/generate-reference-softcore-potential.ipynb
@@ -446,7 +446,7 @@
     "\n",
     "function run {\n",
     "    complexes=../../../src/complexes++\n",
-    "    $complexes -c test.config --rerun=True --nb-thread=1 --backup=false\n",
+    "    $complexes -c test.config --rerun=True --nb-threads=1 --backup=false\n",
     "}\n",
     "\n",
     "function testit {\n",

--- a/complexes++/test/app-test/soft-core-energy/run.sh
+++ b/complexes++/test/app-test/soft-core-energy/run.sh
@@ -5,7 +5,7 @@ set -e
 
 function run {
     complexes=../../../src/complexes++
-    $complexes -c test.config --rerun=True --nb-thread=1 --backup=false
+    $complexes -c test.config --rerun=True --nb-threads=1 --backup=false
 }
 
 function testit {

--- a/complexes++/test/app-test/wca-energy/generate-reference-wca-potential.ipynb
+++ b/complexes++/test/app-test/wca-energy/generate-reference-wca-potential.ipynb
@@ -420,7 +420,7 @@
     "\n",
     "function run {\n",
     "    complexes=../../../src/complexes++\n",
-    "    $complexes -c test.config --rerun=True --nb-thread=1 --backup=false\n",
+    "    $complexes -c test.config --rerun=True --nb-threads=1 --backup=false\n",
     "}\n",
     "\n",
     "function testit {\n",

--- a/complexes++/test/app-test/wca-energy/run.sh
+++ b/complexes++/test/app-test/wca-energy/run.sh
@@ -5,7 +5,7 @@ set -e
 
 function run {
     complexes=../../../src/complexes++
-    $complexes -c test.config --rerun=True --nb-thread=1 --backup=false
+    $complexes -c test.config --rerun=True --nb-threads=1 --backup=false
 }
 
 function testit {

--- a/complexes++/test/statistic-test/gaussian-domain/Linker distribution testing.ipynb
+++ b/complexes++/test/statistic-test/gaussian-domain/Linker distribution testing.ipynb
@@ -592,7 +592,7 @@
     }
    ],
    "source": [
-    "!complexes++ -c sim-collision.conf --backup=false --nb-thread=1"
+    "!complexes++ -c sim-collision.conf --backup=false --nb-threads=1"
    ]
   },
   {


### PR DESCRIPTION
In my previous branch #30 it was possible to pass a parameter that is invalid (like comples++ SQDFQSD).
It is not the case anymore. I wait for the CI to see if everything is fine, and that would be great if anyone can do a quick test on a PC.