### PR TITLE
Clean cl names

### DIFF
--- a/complexes++/ext/CLsimple/clsimple.hpp
+++ b/complexes++/ext/CLsimple/clsimple.hpp
@@ -445,16 +445,17 @@ public:
                 groupStates[param->mandatoryGroup()] &= hasOneOfKeys(keys);
             }
         }
-        bool oneGroupIsOk = false;
-        for(auto iter : groupStates){
-            oneGroupIsOk = iter.second;
-            if(oneGroupIsOk){
-                break;
+        if(groupStates.size()){
+            bool oneGroupIsOk = false;
+            for(auto iter : groupStates){
+                oneGroupIsOk = iter.second;
+                if(oneGroupIsOk){
+                    break;
+                }
             }
+
+            _isValid &= oneGroupIsOk;
         }
-
-        _isValid &= oneGroupIsOk;
-
         return _isValid;
     }
 

--- a/complexes++/ext/CLsimple/clsimple.hpp
+++ b/complexes++/ext/CLsimple/clsimple.hpp
@@ -228,24 +228,24 @@ class CLsimple{
     };
 
     static bool StrSeemsAKey(const std::string& str){
-        std::regex keyFormat("-{1,2}(\\D|[0-9]\\D)");
+        std::regex keyFormat("^-{1,2}(\\D|[0-9]+\\D)");
         return std::regex_search(str, keyFormat);
     }
 
     static std::string StrToKey(const std::string& str){
-        std::regex keyValueFormat("-{1,2}([^=]+).*");
+        std::regex keyValueFormat("^-{1,2}([^=]+).*");
         std::smatch match;
         std::regex_search(str, match, keyValueFormat);
         return match[1];
     }
 
     static bool IsKeyValueFormat(const std::string& str){
-        std::regex keyValueFormat("--[^=]+=.+");
+        std::regex keyValueFormat("^--[^=]+=.+");
         return std::regex_search(str, keyValueFormat);
     }
 
     static std::pair<std::string,std::string> SplitKeyValue(const std::string& str){
-        std::regex keyValueFormat("--([^=]+)=(.+)");
+        std::regex keyValueFormat("^--([^=]+)=(.+)");
         std::smatch match;
         std::regex_search(str, match, keyValueFormat);
         const std::string key = match[1];

--- a/complexes++/ext/CLsimple/clsimple.hpp
+++ b/complexes++/ext/CLsimple/clsimple.hpp
@@ -285,6 +285,23 @@ class CLsimple{
                 if(parseIsOK){
                     (*parseIsOK) &= res;
                 }
+                if(param->isMulti()){
+                    int idxVal = pos + 1;
+                    while(idxVal != int(_argv.size()) && !StrSeemsAKey(_argv[idxVal])){
+                        const bool res = param->applyValue(_argv[idxVal]);
+                        if(!res){
+                            (*errorStr) << "[ERROR] Error in parsing the value \"" << _argv[idxVal] << "\" for arg \""
+                                     << _argv[pos] << "\"\n";
+                        }
+                        if(parseIsOK){
+                            (*parseIsOK) &= res;
+                        }
+                        if(usedFields){
+                            (*usedFields).insert(idxVal);
+                        }
+                        idxVal += 1;
+                    }
+                }
             }
             else if(pos+1 != int(_argv.size())){
                 if(param->isMulti()){

--- a/complexes++/src/setup/cliargs.h
+++ b/complexes++/src/setup/cliargs.h
@@ -50,9 +50,9 @@ public:
                                        restart, "");
         args.addParameter<int>({"replex"}, "number of sweeps between exchanges",
                                replex, 0);
-        args.addParameter<int>({"replex_stat"}, "number of sweeps between statistic output",
+        args.addParameter<int>({"replex-stat"}, "number of sweeps between statistic output",
                                replex_stat, 1000);
-        args.addParameter<std::string>({"replex_accept"}, "exchange accept function",
+        args.addParameter<std::string>({"replex-accept"}, "exchange accept function",
                                        replex_accept, "");
         args.addParameter<std::string>({"movestats"},
                                      "specify the move statistics to show. Could be pertype, "
@@ -60,7 +60,7 @@ public:
                                       movestats, "pertype");
         args.addParameter<int>({"nb-threads"}, "number of threads",
                                nb_threads, omp_get_max_threads());
-        args.addParameter<std::string>({"replex_verbosity"}, "exchange log verbosity (stats, all, none)",
+        args.addParameter<std::string>({"replex-verbosity"}, "exchange log verbosity (stats, all, none)",
                                        replex_verbosity, "stats");
 
     }


### PR DESCRIPTION
Typos, I was using "_" instead of "-" for the parameters, now should always be "-", like "nb-threads=x".
I now print the errors from the command line.
I now accept --list-param=x y z in addition to --list-param x y z (so with and without =)