### PR TITLE
Fix compilation of docs

### DIFF
--- a/complexes++/CMakeLists.txt
+++ b/complexes++/CMakeLists.txt
@@ -163,7 +163,7 @@ endif()
 find_package(Doxygen)
 if(DOXYGEN_FOUND)
     message( STATUS "Doxygen has been found, use \"make doc\" to generate the documentation." )
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../manual/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../docs/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
     add_custom_target(
         doc
         ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile

--- a/complexes++/README.MD
+++ b/complexes++/README.MD
@@ -12,7 +12,7 @@
 
 
 complexes++ is a Monte-Carlo engine for coarse grained protein models. For an
-explanation of the implemented algorithms please have a look into the [manual](../manual/manual.pdf).
+explanation of the implemented algorithms please have a look into the [docs](../docs/).
 
 
 You can find examples of using complexes++ in the pycomplexes included [tutorials](../pycomplexes/tutorials).


### PR DESCRIPTION
Correct small typo in CMakelists.txt:

directory `manual` has been renamed to `docs`.
This was not adapted in CMakeLists.txt up to now.